### PR TITLE
Add course detail page with lesson navigation

### DIFF
--- a/routes/courses.js
+++ b/routes/courses.js
@@ -4,6 +4,8 @@ var express = require('express');
 var router = express.Router();
 
 const coursesRepo = require('../db/coursesRepo');
+const lessonsRepo = require('../db/lessonsRepo');
+
 
 // GET /courses - list courses
 router.get('/', function (req, res, next) {
@@ -21,6 +23,27 @@ router.get('/new', function (req, res, next) {
   try {
     res.locals.pageCss = '/stylesheets/pages/courses.css';
     res.render('courses/new', { form: { title: '', description: '' }, error: null });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /courses/:id - course detail page (with lessons). 
+// Must be after /new route!
+router.get('/:id', function (req, res, next) {
+  try {
+    res.locals.pageCss = '/stylesheets/pages/courses.css';
+
+    const id = parseInt(req.params.id, 10);
+    const course = coursesRepo.getCourseById(id);
+
+    if (!course) {
+      return res.status(404).send('Course not found');
+    }
+
+    const lessons = lessonsRepo.getLessonsByCourseId(id, { includeUnpublished: true });
+
+    res.render('courses/show', { course, lessons });
   } catch (err) {
     next(err);
   }

--- a/routes/lessons.js
+++ b/routes/lessons.js
@@ -27,22 +27,6 @@ router.get('/', function (req, res, next) {
   }
 });
 
-// GET /lessons/:id - show lesson detail
-router.get('/:id', function (req, res, next) {
-  try {
-    res.locals.pageCss = '/stylesheets/pages/courses.css';
-
-    const id = parseInt(req.params.id, 10);
-    const lesson = lessonsRepo.getLessonById(id);
-    if (!lesson) return res.status(404).send('Lesson not found');
-
-    const course = coursesRepo.getCourseById(lesson.course_id);
-
-    res.render('lessons/show', { lesson, course });
-  } catch (err) {
-    next(err);
-  }
-});
 
 
 // GET /lessons/new?course_id=1 - show create lesson form
@@ -210,5 +194,23 @@ router.post('/:id/delete', function (req, res, next) {
     next(err);
   }
 });
+
+// GET /lessons/:id - show lesson detail
+router.get('/:id', function (req, res, next) {
+  try {
+    res.locals.pageCss = '/stylesheets/pages/courses.css';
+
+    const id = parseInt(req.params.id, 10);
+    const lesson = lessonsRepo.getLessonById(id);
+    if (!lesson) return res.status(404).send('Lesson not found');
+
+    const course = coursesRepo.getCourseById(lesson.course_id);
+
+    res.render('lessons/show', { lesson, course });
+  } catch (err) {
+    next(err);
+  }
+});
+
 
 module.exports = router;

--- a/views/courses/index.ejs
+++ b/views/courses/index.ejs
@@ -10,8 +10,10 @@
     <ul class="card-list">
       <% courses.forEach(course => { %>
         <li class="card">
-          <h2 class="card-title"><%= course.title %></h2>
-          <p class="card-desc"><%= course.description %></p>
+        <h2 class="card-title">
+            <a class="link" href="/courses/<%= course.id %>"><%= course.title %></a>
+        </h2>          
+        <p class="card-desc"><%= course.description %></p>
           <div class="card-meta">
             <span>ID: <%= course.id %></span>
             <span>Created: <%= course.created_at %></span>

--- a/views/courses/show.ejs
+++ b/views/courses/show.ejs
@@ -1,0 +1,51 @@
+<div class="page">
+  <header class="page-header">
+    <div>
+      <h1><%= course.title %></h1>
+      <p class="muted"><%= course.description %></p>
+    </div>
+
+    <div class="header-actions">
+      <a class="btn-secondary" href="/courses">← Back</a>
+      <a class="btn" href="/lessons/new?course_id=<%= course.id %>">+ New Lesson</a>
+    </div>
+  </header>
+
+  <h2>Lessons</h2>
+
+  <% if (!lessons || lessons.length === 0) { %>
+    <p class="muted">No lessons yet for this course.</p>
+  <% } else { %>
+    <ul class="card-list">
+      <% lessons.forEach(lesson => { %>
+        <li class="card">
+          <div class="card-row">
+            <h3 class="card-title" style="margin:0;">
+              <a class="link" href="/lessons/<%= lesson.id %>"><%= lesson.title %></a>
+            </h3>
+            <span class="badge"><%= lesson.is_published ? 'Published' : 'Draft' %></span>
+          </div>
+
+          <% if (lesson.description) { %>
+            <p class="card-desc"><%= lesson.description %></p>
+          <% } %>
+
+          <div class="card-meta">
+            <span>Position: <%= lesson.position %></span>
+            <span>ID: <%= lesson.id %></span>
+          </div>
+
+          <div class="card-actions">
+            <a class="btn-secondary" href="/lessons/<%= lesson.id %>">View</a>
+            <a class="btn-secondary" href="/lessons/<%= lesson.id %>/edit">Edit</a>
+
+            <form method="POST" action="/lessons/<%= lesson.id %>/delete" class="inline-form"
+                  onsubmit="return confirm('Delete this lesson?');">
+              <button class="btn-danger" type="submit">Delete</button>
+            </form>
+          </div>
+        </li>
+      <% }) %>
+    </ul>
+  <% } %>
+</div>


### PR DESCRIPTION
- Added a course detail route and view to display course information along with its associated lessons

- Updated course listing to link course titles to their detail pages

- Integrated lesson retrieval into the course view to allow navigation from courses to lessons and individual lesson pages

- Adjusted lesson route ordering to ensure correct matching for lesson detail and edit routes

- Enables a complete navigation flow: courses → course page → lessons

Related to: #10 #11 #13