### PR TITLE
29: Extract shared audit logging helper for non-blocking admin monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # hbv506m_video_lesson_platform
+
 Make sure you update to the latest version of Node: Node.js v20.18.2
 
 # To run the app
-1. Make sure homebrew & node are up to date: 
+
+1. Make sure homebrew & node are up to date:
 ```homebrew update```
 ```homebrew upgrade node```
-2. Clone project: 
+2. Clone project:
 ```git clone {http/SSH}```
-3. Move to project directory: 
+3. Move to project directory:
 ```cd hbv506m_video_lesson_platform```
-4. Install dependencies: 
+4. Install dependencies:
 ```npm install```
-5. Launch app on localhost: 
+5. Launch app on localhost:
 ```npm start``
 
 # Development Branch Strategy
+
 No development beyond initial setup should be done on main.
 
 Work on a feature branch, then use merge feature branch into main and resolve any potential conflicts.
 
 Pick an Issue from the Github Issues tracker, assign it to yourself, then use the "Create a branch" option there to automatically create the issue-branch linked to the issue.
 
-https://github.com/krisak11/hbv506m_video_lesson_platform/issues/
-
+<https://github.com/krisak11/hbv506m_video_lesson_platform/issues/>

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -31,7 +31,7 @@ router.get('/monitor', function (req, res, next) {
   const logPath = path.join(__dirname, '..', 'logs', 'app.log');
   const fileLogTail = tailFile(logPath, 120);
 
-  // Uptime command
+  // OS Uptime command 
   exec('uptime', { timeout: 1500 }, (err, stdout, stderr) => {
     const uptimeOutput = err
       ? `Error running uptime: ${err.message}`

--- a/utils/auditLogger.js
+++ b/utils/auditLogger.js
@@ -1,0 +1,15 @@
+const auditLogsRepo = require('../db/auditLogsRepo');
+
+// Helper to log audit events without blocking main flow
+function safeAuditLog(payload) {
+  try {
+    auditLogsRepo.logEvent(payload);
+  } catch (e) {
+    // Do not block core CRUD functionality if audit logging fails
+    console.warn('Audit log failed:', e.message);
+  }
+}
+
+module.exports = {
+  safeAuditLog,
+};


### PR DESCRIPTION
- Introduced a reusable audit logging helper to centralize application audit log writes and prevent logging failures from blocking core CRUD functionality

- Refactored route handlers to use the shared helper instead of duplicating try/catch logging logic

- Improves maintainability, consistency, and robustness of admin monitoring and audit logging across the application

Related to: #29