### PR TITLE
22: Fix audit log IP capture and normalize admin monitor output

### DIFF
--- a/routes/courses.js
+++ b/routes/courses.js
@@ -96,11 +96,10 @@ router.post('/', function (req, res, next) {
     const newId = coursesRepo.createCourse({ title, description });
 
     // Log audit event (non-blocking)
-    safeAuditLog({
+    safeAuditLog(req,{
         event_type: 'course_created',
         severity: 'info',
         actor_user_id: req.user?.id ?? null, // no auth yet
-        ip: req.ip,
         message: `Course created: ${title}`,
         metadata: { course_id: newId }
     });
@@ -138,11 +137,10 @@ router.post('/:id', function (req, res, next) {
     coursesRepo.updateCourse(id, { title, description });
     
     // Log audit event (non-blocking)
-    safeAuditLog({ 
+    safeAuditLog(req, { 
         event_type: 'course_updated',
         severity: 'info',
         actor_user_id: req.user?.id ?? null,
-        ip: req.ip,
         message: `Course updated: ${title}`,
         metadata: { course_id: id }
     });
@@ -168,11 +166,10 @@ router.post('/:id/delete', function (req, res, next) {
     coursesRepo.deleteCourse(id);
 
     // Log audit event (non-blocking)
-    safeAuditLog({
+    safeAuditLog(req, {
         event_type: 'course_deleted',
         severity: 'warn',
         actor_user_id: req.user?.id ?? null,
-        ip: req.ip,
         message: `Course deleted: ${title}`,
         metadata: { course_id: id }
     });

--- a/routes/lessons.js
+++ b/routes/lessons.js
@@ -98,11 +98,10 @@ router.post('/', function (req, res, next) {
       is_published,
     });
 
-    safeAuditLog({
+    safeAuditLog(req, {
         event_type: 'lesson_created',
         severity: 'info',
         actor_user_id: req.user?.id ?? null,
-        ip: req.ip,
         message: `Lesson created in course ${courseId}  (lessonID: ${newID}) ${title}`,
         metadata: { course_id: courseId, title }
     })
@@ -185,10 +184,9 @@ router.post('/:id', function (req, res, next) {
     });
 
     // Log audit event (non-blocking)
-    safeAuditLog({
+    safeAuditLog(req, {
         event_type: 'lesson_updated',
         severity: 'info',
-        ip: req.ip,
         actor_user_id: req.user?.id ?? null,
         message: `Lesson updated (ID: ${id}): ${title}`,
         metadata: { lesson_id: id, title }
@@ -211,11 +209,10 @@ router.post('/:id/delete', function (req, res, next) {
     const title = lesson.title;
     lessonsRepo.deleteLesson(id);
     // Log audit event (non-blocking)
-    safeAuditLog({
+    safeAuditLog(req,{
         event_type: 'lesson_deleted',
         severity: 'info',
         actor_user_id: req.user?.id ?? null,
-        ip: req.ip,
         message: `Lesson deleted (ID: ${id}): ${title}`,
         metadata: { lesson_id: id, title }
     })

--- a/utils/auditLogger.js
+++ b/utils/auditLogger.js
@@ -1,15 +1,16 @@
 const auditLogsRepo = require('../db/auditLogsRepo');
 
-// Helper to log audit events without blocking main flow
-function safeAuditLog(payload) {
+// Safely log an audit event, catching and logging any errors internally
+function safeAuditLog(req, payload) {
   try {
-    auditLogsRepo.logEvent(payload);
+    auditLogsRepo.logEvent({
+      ...payload,
+      ip_address: req?.ip ?? null,
+      user_agent: req?.get?.('User-Agent') ?? null,
+    });
   } catch (e) {
-    // Do not block core CRUD functionality if audit logging fails
     console.warn('Audit log failed:', e.message);
   }
 }
 
-module.exports = {
-  safeAuditLog,
-};
+module.exports = { safeAuditLog };

--- a/views/admin/monitor.ejs
+++ b/views/admin/monitor.ejs
@@ -26,6 +26,7 @@
               <th>Severity</th>
               <th>Event</th>
               <th>Actor</th>
+              <th>IP Address</th>
               <th>Message</th>
             </tr>
           </thead>
@@ -36,6 +37,7 @@
                 <td><span class="badge badge-<%= log.severity %>"><%= log.severity %></span></td>
                 <td><%= log.event_type %></td>
                 <td><%= log.actor_user_id || '-' %></td>
+                <td><%= log.ip_address || '-' %></td>
                 <td><%= log.message || '' %></td>
               </tr>
             <% }) %>


### PR DESCRIPTION
- Corrected audit logging to consistently store client IP addresses using the ip_address field

- Fixed a typo that caused some audit log entries to be written without an IP value

- Verified that admin monitor correctly displays client IPs (e.g. ::1 in local development)

- Ensures accurate and consistent audit trail data for administrative monitoring

Related to: #22