### PR TITLE
Align application logging with LOG_PATH environment variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,17 +38,18 @@ app.set('trust proxy', true);
 
 // middleware setup
 
-// ensure logs directory exists
-const logsDir = path.join(__dirname, 'logs');
-fs.mkdirSync(logsDir, { recursive: true });
+// ensure logs directory exists and create write stream for application logs
 
-// create write stream for application logs
-const accessLogStream = fs.createWriteStream(
-  path.join(logsDir, 'app.log'),
-  { flags: 'a' }
-);
+const defaultLogFile = path.join(__dirname, 'logs', 'app.log');
+const logFilePath = process.env.LOG_PATH || defaultLogFile;
 
-// log HTTP requests to file
+// Ensure the parent directory exists
+fs.mkdirSync(path.dirname(logFilePath), { recursive: true });
+
+// Create write stream for application logs
+const accessLogStream = fs.createWriteStream(logFilePath, { flags: 'a' });
+
+// Log HTTP requests to file
 app.use(logger('combined', { stream: accessLogStream }));
 
 // also log to console

--- a/db/index.js
+++ b/db/index.js
@@ -2,7 +2,7 @@ const Database = require('better-sqlite3'); // SQLite library, synchronous and f
 const path = require('path'); // For handling file paths
 const fs = require('fs'); // File system module
 
-const dbPath = path.join(__dirname, '..', 'data', 'app.db'); // Path to the SQLite database file
+const dbPath = process.env.DB_PATH || path.join(__dirname, '..', 'data', 'app.db'); // Path to the SQLite database file
 
 // Ensure data folder exists
 fs.mkdirSync(path.dirname(dbPath), { recursive: true });

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -28,7 +28,7 @@ router.get('/monitor', function (req, res, next) {
   }
 
   // Tail file log (optional)
-  const logPath = path.join(__dirname, '..', 'logs', 'app.log');
+  const logPath = process.env.LOG_PATH || path.join(__dirname, '..', 'logs', 'app.log');
   const fileLogTail = tailFile(logPath, 120);
 
   // OS Uptime command 


### PR DESCRIPTION
- Treat LOG_PATH as a log file path instead of a directory
- Ensure parent log directory is created safely at startup
- Update HTTP request logging to write consistently to LOG_PATH
- Align admin monitor log tailing with the same configured log file
- Improves deployment readiness and prevents filesystem path errors on VM

Related to: #31