### PR TITLE
feat(auth): migrate session storage to Redis (production-ready stateful sessions)

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -1,68 +1,77 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
+const http = require('http');
+const debug = require('debug')('video-lesson-platform:server');
 
-var app = require('../app');
-var debug = require('debug')('video-lesson-platform:server');
-var http = require('http');
+const { createClient } = require('redis');
 
-/**
- * Get port from environment and store in Express.
- */
+// ✅ Most common correct import for connect-redis in CJS:
+const { RedisStore } = require('connect-redis');
 
-var port = normalizePort(process.env.PORT || '3000');
-app.set('port', port);
+const { createApp } = require('../app');
 
-/**
- * Create HTTP server.
- */
+const port = normalizePort(process.env.PORT || '3000');
 
-var server = http.createServer(app);
+async function main() {
+  // --------------------------
+  // Connect Redis (optional in dev)
+  // --------------------------
+  let sessionStore = undefined;
 
-/**
- * Listen on provided port, on all network interfaces.
- */
+  const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+  const redisClient = createClient({ url: redisUrl });
 
-server.listen(port, '0.0.0.0');
-server.on('error', onError);
-server.on('listening', onListening);
+  redisClient.on('error', (err) => {
+    console.error('Redis Client Error:', err);
+  });
 
-/**
- * Normalize a port into a number, string, or false.
- */
+  try {
+    await redisClient.connect();
+    console.log('Connected to Redis for session storage.');
+
+    sessionStore = new RedisStore({
+      client: redisClient,
+      prefix: 'vlp:sess:',
+    });
+  } catch (err) {
+    console.error('Failed to connect to Redis.');
+    console.error(err);
+
+    // Fail fast in production; allow fallback in dev if we want
+    if (process.env.NODE_ENV === 'production') {
+      process.exit(1);
+    } else {
+      console.warn('Continuing with MemoryStore for dev (NOT for production).');
+    }
+  }
+
+  // Build app with store (or without if Redis failed)
+  const app = createApp({ sessionStore });
+  app.set('port', port);
+
+  const server = http.createServer(app);
+  server.listen(port, '0.0.0.0');
+  server.on('error', onError);
+  server.on('listening', onListening);
+}
+
+main().catch((e) => {
+  console.error('Fatal startup error:', e);
+  process.exit(1);
+});
 
 function normalizePort(val) {
-  var port = parseInt(val, 10);
-
-  if (isNaN(port)) {
-    // named pipe
-    return val;
-  }
-
-  if (port >= 0) {
-    // port number
-    return port;
-  }
-
+  const portNum = parseInt(val, 10);
+  if (isNaN(portNum)) return val;
+  if (portNum >= 0) return portNum;
   return false;
 }
 
-/**
- * Event listener for HTTP server "error" event.
- */
-
 function onError(error) {
-  if (error.syscall !== 'listen') {
-    throw error;
-  }
+  if (error.syscall !== 'listen') throw error;
 
-  var bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port;
+  const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port;
 
-  // handle specific listen errors with friendly messages
   switch (error.code) {
     case 'EACCES':
       console.error(bind + ' requires elevated privileges');
@@ -77,14 +86,9 @@ function onError(error) {
   }
 }
 
-/**
- * Event listener for HTTP server "listening" event.
- */
-
 function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
+  const addr = this.address?.() || null;
+  const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + (addr?.port ?? port);
   debug('Listening on ' + bind);
+  console.log('Listening on ' + bind);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^12.6.2",
+        "connect-redis": "^9.0.0",
         "cookie-parser": "~1.4.4",
         "debug": "~2.6.9",
         "dotenv": "^17.3.1",
@@ -21,7 +22,68 @@
         "http-errors": "~1.6.3",
         "morgan": "^1.10.1",
         "nodemon": "^3.1.11",
+        "redis": "^5.10.0",
         "zxcvbn": "^4.4.2"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
+      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.10.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
+      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
+      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.10.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
+      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.10.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
+      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.10.0"
       }
     },
     "node_modules/accepts": {
@@ -365,11 +427,33 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/connect-redis": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-9.0.0.tgz",
+      "integrity": "sha512-QwzyvUePTMvEzG1hy45gZYw3X3YHrjmEdSkayURlcZft7hqadQ3X39wYkmCqblK2rGlw+XItELYt6GnyG6DEIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "express-session": ">=1",
+        "redis": ">=5"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1583,9 +1667,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1719,6 +1803,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
+      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.10.0",
+        "@redis/client": "5.10.0",
+        "@redis/json": "5.10.0",
+        "@redis/search": "5.10.0",
+        "@redis/time-series": "5.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.6.2",
+    "connect-redis": "^9.0.0",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "dotenv": "^17.3.1",
@@ -22,6 +23,7 @@
     "http-errors": "~1.6.3",
     "morgan": "^1.10.1",
     "nodemon": "^3.1.11",
+    "redis": "^5.10.0",
     "zxcvbn": "^4.4.2"
   }
 }


### PR DESCRIPTION

- Replace default MemoryStore with Redis-backed session store using connect-redis
- Add Redis client initialization with environment-based REDIS_URL
- Configure session store with namespaced key prefix (vlp:sess:)
- Enable proxy-aware session handling (proxy: true) for nginx deployments
- Harden session cookies:
  - httpOnly enabled
  - sameSite=lax
  - secure in production (NODE_ENV check)
- Fail fast in production if Redis connection fails
- Add dotenv support for local development
- Prepare app for horizontal scaling and improved session resilience

This resolves the security and scalability limitations of Express MemoryStore and supports production-grade stateful authentication.

Related to #51