### PR TITLE
feat(security): implement CSRF protection using csurf middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,8 @@ const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 const fs = require('fs');
 const session = require('express-session');
+const csurf = require('csurf'); // anti csrf middleware
+
 
 let indexRouter = require('./routes/index');
 let usersRouter = require('./routes/users');
@@ -80,6 +82,10 @@ function createApp({ sessionStore } = {}) {
 
   app.use(session(sessionOptions));
 
+  // anti csrf middlware
+  const csrfProtection = csurf();
+  app.use(csrfProtection);
+
   // --------------------------
   // User session hydration middleware
   // Must be after session middleware and before any route that needs req.user
@@ -115,6 +121,12 @@ function createApp({ sessionStore } = {}) {
     return next();
   });
 
+
+  app.use((req, res, next) => {
+    res.locals.csrfToken = req.csrfToken();
+    next();
+  });
+
   // --------------------------
   // Routes
   // --------------------------
@@ -128,8 +140,17 @@ function createApp({ sessionStore } = {}) {
   app.use('/lessons', requireAuth, lessonsRouter);
   app.use('/admin', requireAuth, adminRouter);
 
+
   app.use(function (req, res, next) {
     next(createError(404));
+  });
+
+  // CSRF error handler
+  app.use((err, req, res, next) => {
+    if (err.code === 'EBADCSRFTOKEN') {
+      return res.status(403).send('Invalid CSRF token');
+    }
+    next(err);
   });
 
   app.use(function (err, req, res, next) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "better-sqlite3": "^12.6.2",
         "connect-redis": "^9.0.0",
         "cookie-parser": "~1.4.4",
+        "csurf": "^1.11.0",
         "debug": "~2.6.9",
         "dotenv": "^17.3.1",
         "ejs": "^4.0.1",
@@ -43,7 +44,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
       "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -525,6 +525,82 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "license": "MIT",
+      "dependencies": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "deprecated": "This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/csurf/node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/csurf/node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "license": "ISC"
+    },
+    "node_modules/csurf/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -779,7 +855,6 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cookie": "~0.7.2",
         "cookie-signature": "~1.0.7",
@@ -1352,9 +1427,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1512,9 +1587,9 @@
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1812,7 +1887,6 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
       "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.10.0",
         "@redis/client": "5.10.0",
@@ -1823,6 +1897,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -2091,9 +2171,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2205,6 +2285,15 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
       }
     },
     "node_modules/tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
     "start": "nodemon ./bin/www",
     "db:init": "node ./db/init.js",
     "db:smoke": "node db/smokeTest.js",
-    "db:seed": "node db/seed.js" 
+    "db:seed": "node db/seed.js"
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.6.2",
     "connect-redis": "^9.0.0",
     "cookie-parser": "~1.4.4",
+    "csurf": "^1.11.0",
     "debug": "~2.6.9",
     "dotenv": "^17.3.1",
     "ejs": "^4.0.1",

--- a/views/auth/login.ejs
+++ b/views/auth/login.ejs
@@ -12,6 +12,7 @@
     <% } %>
 
     <form action="/auth/login" method="POST">
+      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <div class="form-group">
         <label for="email">Email</label>
         <input

--- a/views/auth/register.ejs
+++ b/views/auth/register.ejs
@@ -12,6 +12,7 @@
     <% } %>
 
     <form action="/auth/register" method="POST">
+      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <div class="form-group">
         <label for="display_name">Name</label>
         <input

--- a/views/courses/edit.ejs
+++ b/views/courses/edit.ejs
@@ -17,6 +17,7 @@
 
   <!-- Update form (inputs only) -->
   <form id="course-edit-form" class="form" method="POST" action="/courses/<%= course.id %>">
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <label class="label">
       Title
       <input class="input" type="text" name="title" value="<%= form.title %>" required>
@@ -34,6 +35,7 @@
 
     <form method="POST" action="/courses/<%= course.id %>/delete" class="inline-form"
           onsubmit="return confirm('Delete this course and all its lessons?');">
+      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <button class="btn-danger" type="submit">Delete</button>
     </form>
   </div>

--- a/views/courses/new.ejs
+++ b/views/courses/new.ejs
@@ -9,6 +9,7 @@
   <% } %>
 
   <form class="form" method="POST" action="/courses">
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <label class="label">
       Title
       <input class="input" type="text" name="title" value="<%= form.title %>" required>

--- a/views/courses/show.ejs
+++ b/views/courses/show.ejs
@@ -16,6 +16,7 @@
         <form method="POST"
               action="/courses/<%= course.id %>/publish-toggle"
               class="inline-form">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
           <button class="<%= course.is_published ? 'btn-danger' : 'btn' %>" type="submit">
             <%= course.is_published ? 'Unpublish' : 'Publish' %>
           </button>
@@ -33,6 +34,7 @@
 
     <% if (canEnroll) { %>
       <form method="POST" action="/courses/<%= course.id %>/enroll" class="inline-form">
+        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button class="btn" type="submit">Enroll</button>
       </form>
     <% } %>
@@ -40,6 +42,7 @@
     <% if (canUnenroll) { %>
       <form method="POST" action="/courses/<%= course.id %>/unenroll" class="inline-form"
             onsubmit="return confirm('Unenroll from this course?');">
+        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button class="btn-danger" type="submit">Unenroll</button>
       </form>
     <% } %>
@@ -77,6 +80,7 @@
 
               <form method="POST" action="/lessons/<%= lesson.id %>/delete" class="inline-form"
                     onsubmit="return confirm('Delete this lesson?');">
+                <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                 <button class="btn-danger" type="submit">Delete</button>
               </form>
             <% } %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -10,6 +10,7 @@
         <h3>Role: <b><%= user.role %></b></h3>
 
         <form action="/auth/logout" method="POST" style="display:inline;">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
           <button type="submit" class="header-nav-btn">Logout</button>
         </form>
       <% } else { %>

--- a/views/lessons/edit.ejs
+++ b/views/lessons/edit.ejs
@@ -19,6 +19,7 @@
 
   <!-- Update form (inputs only) -->
   <form id="lesson-edit-form" class="form" method="POST" action="/lessons/<%= lesson.id %>">
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <label class="label">
       Title
       <input class="input" type="text" name="title" value="<%= form.title %>" required>
@@ -56,6 +57,7 @@
 
     <form method="POST" action="/lessons/<%= lesson.id %>/delete" class="inline-form"
           onsubmit="return confirm('Delete this lesson?');">
+      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <button class="btn-danger" type="submit">Delete</button>
     </form>
   </div>

--- a/views/lessons/index.ejs
+++ b/views/lessons/index.ejs
@@ -38,6 +38,7 @@
 
             <form method="POST" action="/lessons/<%= lesson.id %>/delete" class="inline-form"
                   onsubmit="return confirm('Delete this lesson?');">
+              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <button class="btn-danger" type="submit">Delete</button>
             </form>
           </div>


### PR DESCRIPTION
- Added csurf middleware for global CSRF protection
- Exposed CSRF token to all EJS views via res.locals.csrfToken
- Added hidden _csrf field to state-changing forms (POST routes)
- Implemented centralized EBADCSRFTOKEN error handler (403)
- Ensured middleware ordering: session → csurf → routes → CSRF error handler

All state-changing requests now require a valid CSRF token.

Related to #66